### PR TITLE
dipei2020的maintainer邮箱名称不正确（仅修改dipei2020）

### DIFF
--- a/source/related-docs/git commit --amend
+++ b/source/related-docs/git commit --amend
@@ -1,0 +1,3 @@
+git commit --amend
+git push -f
+

--- a/source/related-docs/maintainers.rst
+++ b/source/related-docs/maintainers.rst
@@ -13,7 +13,7 @@
    :header: "姓名", "GitHub", "Email"
 
    "耿建华", "genggjh", "gengjianhua@arxanchain.com"
-   "狄培", "dipei2020", "dipai@arxanchain.com"
+   "狄培", "dipei2020", "dipei@arxanchain.com"
    "樊晓星", "DrangonBall", "fanxiaoxing@arxanfintech.com"
    "陆琪", "kiwiqiqi", "lqi5@grgbanking.com"
 


### PR DESCRIPTION
邮件名称不是dipai,而是“dipei”